### PR TITLE
Add Jacoco plugin and tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,26 @@
 					</excludes>
 				</configuration>
 			</plugin>
-		</plugins>
-	</build>
+                       <plugin>
+                               <groupId>org.jacoco</groupId>
+                               <artifactId>jacoco-maven-plugin</artifactId>
+                               <version>0.8.10</version>
+                               <executions>
+                                       <execution>
+                                               <goals>
+                                                       <goal>prepare-agent</goal>
+                                               </goals>
+                                       </execution>
+                                       <execution>
+                                               <id>report</id>
+                                               <phase>test</phase>
+                                               <goals>
+                                                       <goal>report</goal>
+                                               </goals>
+                                       </execution>
+                               </executions>
+                       </plugin>
+               </plugins>
+       </build>
 
 </project>

--- a/src/test/java/com/example/bdget/BdgetApplicationTests.java
+++ b/src/test/java/com/example/bdget/BdgetApplicationTests.java
@@ -6,8 +6,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class BdgetApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+        @Test
+        void contextLoads() {
+                BdgetApplication.main(new String[]{});
+        }
 
 }

--- a/src/test/java/com/example/bdget/controller/StudentControllerTest.java
+++ b/src/test/java/com/example/bdget/controller/StudentControllerTest.java
@@ -1,0 +1,85 @@
+package com.example.bdget.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import com.example.bdget.model.Student;
+import com.example.bdget.service.StudentService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StudentService service;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private Student student;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student();
+        student.setId(1L);
+        student.setName("John");
+    }
+
+    @Test
+    void testGetAllStudents() throws Exception {
+        when(service.getAllStudents()).thenReturn(Arrays.asList(student));
+        mockMvc.perform(get("/students"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(mapper.writeValueAsString(Arrays.asList(student))));
+    }
+
+    @Test
+    void testGetStudentById() throws Exception {
+        when(service.getStudentById(1L)).thenReturn(Optional.of(student));
+        mockMvc.perform(get("/students/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(mapper.writeValueAsString(student)));
+    }
+
+    @Test
+    void testCreateStudent() throws Exception {
+        when(service.createStudent(any(Student.class))).thenReturn(student);
+        mockMvc.perform(post("/students")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(student)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(mapper.writeValueAsString(student)));
+    }
+
+    @Test
+    void testUpdateStudent() throws Exception {
+        when(service.updateStudent(eq(1L), any(Student.class))).thenReturn(student);
+        mockMvc.perform(put("/students/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(student)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(mapper.writeValueAsString(student)));
+    }
+
+    @Test
+    void testDeleteStudent() throws Exception {
+        mockMvc.perform(delete("/students/1"))
+                .andExpect(status().isOk());
+        verify(service).deleteStudent(1L);
+    }
+}

--- a/src/test/java/com/example/bdget/model/StudentModelTest.java
+++ b/src/test/java/com/example/bdget/model/StudentModelTest.java
@@ -1,0 +1,16 @@
+package com.example.bdget.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class StudentModelTest {
+    @Test
+    void testGettersAndSetters() {
+        Student student = new Student();
+        student.setId(1L);
+        student.setName("John");
+        assertEquals(1L, student.getId());
+        assertEquals("John", student.getName());
+    }
+}

--- a/src/test/java/com/example/bdget/service/StudentServiceImplTest.java
+++ b/src/test/java/com/example/bdget/service/StudentServiceImplTest.java
@@ -1,0 +1,79 @@
+package com.example.bdget.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.bdget.model.Student;
+import com.example.bdget.repository.StudentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StudentServiceImplTest {
+
+    @Mock
+    private StudentRepository repository;
+
+    @InjectMocks
+    private StudentServiceImpl service;
+
+    private Student student;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student();
+        student.setId(1L);
+        student.setName("John");
+    }
+
+    @Test
+    void testGetAllStudents() {
+        List<Student> expected = Arrays.asList(student);
+        when(repository.findAll()).thenReturn(expected);
+        assertEquals(expected, service.getAllStudents());
+    }
+
+    @Test
+    void testGetStudentById() {
+        when(repository.findById(1L)).thenReturn(Optional.of(student));
+        assertEquals(Optional.of(student), service.getStudentById(1L));
+    }
+
+    @Test
+    void testCreateStudent() {
+        when(repository.save(student)).thenReturn(student);
+        assertEquals(student, service.createStudent(student));
+    }
+
+    @Test
+    void testUpdateStudentExists() {
+        when(repository.existsById(1L)).thenReturn(true);
+        when(repository.save(student)).thenReturn(student);
+        Student result = service.updateStudent(1L, student);
+        assertEquals(1L, student.getId());
+        assertEquals(student, result);
+        verify(repository).save(student);
+    }
+
+    @Test
+    void testUpdateStudentNotExists() {
+        when(repository.existsById(1L)).thenReturn(false);
+        assertNull(service.updateStudent(1L, student));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void testDeleteStudent() {
+        service.deleteStudent(1L);
+        verify(repository).deleteById(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- configure `jacoco-maven-plugin` for coverage
- add unit test for Student model
- add unit tests for StudentServiceImpl
- add MVC tests for StudentController
- test application entrypoint

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856b40607408331ba0858e45b2d26a4