### PR TITLE
Configure bdget service to consume Spring Cloud Config server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,23 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dependencies</artifactId>
+                                <version>2023.0.3</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
+
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -33,16 +45,21 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-starter-config</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc11</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,23 @@
+spring.application.name=bdget
+spring.config.import=optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888}
+spring.cloud.config.fail-fast=false
+spring.cloud.config.retry.max-attempts=5
+spring.cloud.config.retry.initial-interval=1000
+spring.cloud.config.retry.multiplier=1.5
+spring.cloud.config.retry.max-interval=5000
+
 logging.level.root=INFO
 logging.level.org.hibernate=DEBUG
 logging.level.org.springframework=DEBUG
 
-spring.datasource.url=<db_url>     
-spring.datasource.username=<db_username> 
-spring.datasource.password=<db_password> 
+spring.datasource.url=<db_url>
+spring.datasource.username=<db_username>
+spring.datasource.password=<db_password>
 spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.OracleDialect
 spring.jpa.hibernate.ddl-auto=none
 
-spring.datasource.hikari.maximum-pool-size= 10
-spring.datasource.hikari.connection-timeout= 30000
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.connection-timeout=30000
 
-server:
- port: 8080
+server.port=8080


### PR DESCRIPTION
## Summary
- import the Spring Cloud dependency BOM and add the config starter to the service
- configure the application to contact the external config server with retry settings and explicit app name

## Testing
- `sh mvnw test` *(fails: unable to download Maven wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c89866db708331b92eabfafe6d56d9